### PR TITLE
Optional timesheetId when creating a timeEntry - Added Permission check for timeEntry Endpoints

### DIFF
--- a/backend/controller/time_entry_controller.py
+++ b/backend/controller/time_entry_controller.py
@@ -2,6 +2,8 @@ from flask import Blueprint, request, jsonify
 from flask.views import MethodView
 from flask_jwt_extended import jwt_required, get_jwt_identity
 
+from model.user.role import UserRole
+from service.auth_service import check_access
 from service.time_entry_service import TimeEntryService
 from service.timesheet_service import TimesheetService
 
@@ -60,6 +62,7 @@ class TimeEntryController(MethodView):
         return jsonify({'error': 'Endpoint not found'}), 404
 
     @jwt_required()
+    @check_access(roles=[UserRole.HIWI])
     def create_work_entry(self):
         """
         Creates a new time entry with the provided JSON data.
@@ -74,6 +77,7 @@ class TimeEntryController(MethodView):
         return jsonify(result.message), result.status_code
 
     @jwt_required()
+    @check_access(roles=[UserRole.HIWI])
     def create_vacation_entry(self):
         """
         Creates a new vacation time entry with the provided JSON data.
@@ -88,6 +92,7 @@ class TimeEntryController(MethodView):
         return jsonify(result.message), result.status_code
 
     @jwt_required()
+    @check_access(roles=[UserRole.HIWI])
     def update_time_entry(self):
         """
         Updates an existing time entry using the provided JSON data.
@@ -103,6 +108,7 @@ class TimeEntryController(MethodView):
         return jsonify(result.message), result.status_code
 
     @jwt_required()
+    @check_access(roles=[UserRole.HIWI])
     def delete_time_entry(self):
         """
         Deletes a time entry identified by its ID provided in the JSON data.

--- a/backend/service/time_entry_service.py
+++ b/backend/service/time_entry_service.py
@@ -1,3 +1,5 @@
+import datetime
+
 from bson import ObjectId
 from flask_jwt_extended import get_jwt_identity
 
@@ -48,6 +50,12 @@ class TimeEntryService:
         :rtype: RequestResult
         """
         entry_data['entryType'] = entry_type.value
+        if entry_data.get('timesheetId') is None:
+            start_date = datetime.datetime.fromisoformat(entry_data['startTime'])
+            self.timesheet_service.ensure_timesheet_exists(username, start_date.month, start_date.year)
+            timesheet_id = self.timesheet_service.get_timesheet(username, start_date.month, start_date.year).data.timesheet_id
+            entry_data['timesheetId'] = str(timesheet_id)
+                        
         validation_result = self.entry_validator.is_valid(entry_data)
         if validation_result.status == ValidationStatus.FAILURE:
             return RequestResult(False, validation_result.message, status_code=400)


### PR DESCRIPTION
This pull requests makes the timesheetId parameter in the createWorkEntry / createVacationEntry Endpoints optional. If the timesheetId value is missing in the request, the month and year of the startDate value are used to retrieve the timesheetId.
As the "ensure_timesheet_exists" method is used, the timesheet will be created if it did not previously exist.

Permission check:
I have also added an authorization check for creating, updating and deleting timeEntries, so that only hiwis can modify them.