### PR TITLE
Require an uploaded signautre for signing, approving and requestion change on timesheets

### DIFF
--- a/backend/controller/timesheet_controller.py
+++ b/backend/controller/timesheet_controller.py
@@ -1,9 +1,11 @@
 from flask import jsonify, request, Blueprint
 from flask.views import MethodView
-from flask_jwt_extended import jwt_required
+from flask_jwt_extended import jwt_required, get_jwt_identity
 
+from model.file.FileType import FileType
 from model.user.role import UserRole
 from service.auth_service import check_access
+from service.file_service import FileService
 from service.timesheet_service import TimesheetService
 
 timesheet_blueprint = Blueprint('timesheet', __name__)
@@ -20,6 +22,7 @@ class TimesheetController(MethodView):
         Initializes TimesheetController with an instance of TimesheetService.
         """
         self.timesheet_service = TimesheetService()
+        self.file_service = FileService()
 
     def get(self):
         """
@@ -92,6 +95,8 @@ class TimesheetController(MethodView):
         timesheet_id = request_data['_id']
         if timesheet_id is None:
             return jsonify({'error': 'No timesheet ID provided'}), 400
+        if not self.file_service.does_file_exist(get_jwt_identity(), FileType.SIGNATURE):
+            return jsonify({'error': 'No signature has been uploaded.'}), 400
         result = self.timesheet_service.sign_timesheet(timesheet_id)
         return jsonify(result.message), result.status_code
 
@@ -109,6 +114,8 @@ class TimesheetController(MethodView):
         timesheet_id = request_data['_id']
         if timesheet_id is None:
             return jsonify({'error': 'No timesheet ID provided'}), 400
+        if not self.file_service.does_file_exist(get_jwt_identity(), FileType.SIGNATURE):
+            return jsonify({'error': 'No signature has been uploaded.'}), 400
         result = self.timesheet_service.approve_timesheet(timesheet_id)
         return jsonify(result.message), result.status_code
 
@@ -126,6 +133,8 @@ class TimesheetController(MethodView):
         timesheet_id = request_data['_id']
         if timesheet_id is None:
             return jsonify({'error': 'No timesheet ID provided'}), 400
+        if not self.file_service.does_file_exist(get_jwt_identity(), FileType.SIGNATURE):
+            return jsonify({'error': 'No signature has been uploaded.'}), 400
         result = self.timesheet_service.request_change(timesheet_id)
         return jsonify(result.message), result.status_code
 

--- a/backend/tests/repository/test_timesheet_repository.py
+++ b/backend/tests/repository/test_timesheet_repository.py
@@ -87,17 +87,17 @@ class TestTimesheetRepository(unittest.TestCase):
         """
         Test the get_timesheet_by_status method of the TimesheetRepository class.
         """
-        test_timesheet_data = [{'_id': ObjectId('6679ca2935df0d8f7202c5fa'),
-                                'username': 'testHiwi1',
-                                'month': 5,
-                                'year': 2024,
-                                'status': 'Not Submitted',
-                                'totalTime': 0.0,
-                                'overtime': 0.0,
-                                'lastSignatureChange': datetime.datetime(2024, 6, 24, 21, 22, 35, 855000)}]
+        test_timesheet_data = {'_id': ObjectId('6679ca2935df0d8f7202c5fa'),
+                               'username': 'testHiwi1',
+                               'month': 5,
+                               'year': 2024,
+                               'status': 'Not Submitted',
+                               'totalTime': 0.0,
+                               'overtime': 0.0,
+                               'lastSignatureChange': datetime.datetime(2024, 6, 24, 21, 22, 35, 855000)}
 
         self.assertEqual(test_timesheet_data,
-                         self.timesheet_repository.get_timesheets_by_status(TimesheetStatus.NOT_SUBMITTED))
+                         self.timesheet_repository.get_timesheets_by_status(TimesheetStatus.NOT_SUBMITTED)[0])
 
     def test_get_timesheet_id(self):
         """

--- a/backend/tests/repository/test_user_repository.py
+++ b/backend/tests/repository/test_user_repository.py
@@ -87,13 +87,13 @@ class TestUserRepository(unittest.TestCase):
         """
         test_user_data = {'_id': ObjectId('667c433eba00f12151afe642'),
                           'username': 'testAdmin1',
-                          'passwordHash': '$2b$12$MMkaSHJ8YaXG4pEjWbDIbOuWxuyVPdajSdsZL/p.HY9IuwN/08Ymy',
                           'personalInfo': {'firstName': 'Nico', 'lastName': 'Admin',
                                            'email': 'test@gmail1.com', 'personalNumber': '6981211',
-                                           'instituteName': 'Info Institute'}, 'role': 'Admin',
-                          'accountCreation': datetime.datetime(2024, 6, 30, 18, 53, 51, 321000)}
+                                           'instituteName': 'Info Institute'}, 'role': 'Admin'}
         received_user_data = self.user_repository.find_by_username("testAdmin1")
         received_user_data.pop("lastLogin")
+        received_user_data.pop("accountCreation")
+        received_user_data.pop("passwordHash")
         self.assertEqual(test_user_data, received_user_data)
 
     def test_update_user(self):


### PR DESCRIPTION
This request solves the issue https://github.com/intuitive-robots/pse-ss24-timetrack/issues/79. 