### PR TITLE
Bug in Time Entry Update Allowing Date Changes Across Different Timesheet Months

### DIFF
--- a/backend/service/time_entry_service.py
+++ b/backend/service/time_entry_service.py
@@ -159,6 +159,11 @@ class TimeEntryService:
         updated_time_entry.set_id(ObjectId(entry_id))
         if not updated_time_entry:
             return RequestResult(False, "Failed to construct updated time entry", status_code=500)
+        existing_start_date = datetime.datetime.fromisoformat(str(existing_entry_data['startTime']))
+        updated_start_date = updated_time_entry.start_time
+        if existing_start_date.month != updated_start_date.month or existing_start_date.year != updated_start_date.year:
+            return RequestResult(False, "Cannot update time entry to a different month or year", status_code=400)
+
 
         repo_result = self.time_entry_repository.update_time_entry(updated_time_entry)
         if not repo_result.is_successful:


### PR DESCRIPTION
Fixed issue #123  by not allowing timeEntries to be moved to another month.