### PR TITLE
Changed StatusType Revision to Waiting for Secretary

### DIFF
--- a/frontend/src/components/status/StatusMapping.ts
+++ b/frontend/src/components/status/StatusMapping.ts
@@ -41,7 +41,7 @@ export const statusMapping: RoleStatusMaps = {
     },
     Secretary: {
         [TimesheetStatus.NotSubmitted]: StatusType.Waiting,
-        [TimesheetStatus.Revision]: StatusType.Revision,
+        [TimesheetStatus.Revision]: StatusType.Waiting,
         [TimesheetStatus.WaitingForApproval]: StatusType.Waiting,
         [TimesheetStatus.Complete]: StatusType.Complete,
         [TimesheetStatus.NoTimesheet]: StatusType.NoTimesheet,


### PR DESCRIPTION
No need for the secretary to see if a timesheet status is Revision or Waiting. 
Compress into one status for filtering simplicity.