### PR TITLE
Issue #134 Improve and standadize Error Messaging

### DIFF
--- a/backend/controller/document_controller.py
+++ b/backend/controller/document_controller.py
@@ -48,8 +48,12 @@ class DocumentController(MethodView):
         month = int(request_data.get('month'))
         year = int(request_data.get('year'))
         username = request_data.get('username')
-        if not month or not year or not username:
-            return jsonify('Missing required fields'), 400
+        if not username:
+            return jsonify('No username provided'), 400
+        if not year:
+            return jsonify('No year provided'), 400
+        if not month:
+            return jsonify('No month provided'), 400
 
         result = self.document_service.generate_document(month, year, username, get_jwt_identity())
         if result.status_code != 200:
@@ -120,5 +124,5 @@ class DocumentController(MethodView):
         for path, func in endpoint_mapping.items():
             if request_path.endswith(path):
                 return func()
-        return jsonify({'error': 'Endpoint not found'}), 404
+        return jsonify('Endpoint not found'), 404
 

--- a/backend/controller/time_entry_controller.py
+++ b/backend/controller/time_entry_controller.py
@@ -59,7 +59,7 @@ class TimeEntryController(MethodView):
         for path, func in endpoint_mapping.items():
             if request_path.endswith(path):
                 return func()
-        return jsonify({'error': 'Endpoint not found'}), 404
+        return jsonify('Endpoint not found'), 404
 
     @jwt_required()
     @check_access(roles=[UserRole.HIWI])
@@ -70,7 +70,7 @@ class TimeEntryController(MethodView):
         :return: JSON response containing the status message and status code.
         """
         if not request.is_json:
-            return jsonify({'error': 'Request data must be in JSON format'}), 400
+            return jsonify('Request data must be in JSON format'), 400
         time_entry_data = request.get_json()
         username = get_jwt_identity()
         result = self.time_entry_service.create_work_entry(time_entry_data, username)
@@ -85,7 +85,7 @@ class TimeEntryController(MethodView):
         :return: JSON response containing the status message and status code.
         """
         if not request.is_json:
-            return jsonify({'error': 'Request data must be in JSON format'}), 400
+            return jsonify('Request data must be in JSON format'), 400
         vacation_data = request.get_json()
         username = get_jwt_identity()
         result = self.time_entry_service.create_vacation_entry(vacation_data, username)
@@ -100,7 +100,7 @@ class TimeEntryController(MethodView):
         :return: JSON response containing the status message and status code.
         """
         if not request.is_json:
-            return jsonify({'error': 'Request data must be in JSON format'}), 400
+            return jsonify('Request data must be in JSON format'), 400
         time_entry_data = request.get_json()
         time_entry_id = time_entry_data.get('_id')
         time_entry_data.pop('_id')
@@ -116,7 +116,7 @@ class TimeEntryController(MethodView):
         :return: JSON response containing the status message and status code.
         """
         if not request.is_json:
-            return jsonify({'error': 'Request data must be in JSON format'}), 400
+            return jsonify('Request data must be in JSON format'), 400
         time_entry_id = request.get_json().get('timeEntryId')
         result = self.time_entry_service.delete_time_entry(time_entry_id)
         return jsonify(result.message), result.status_code

--- a/backend/controller/timesheet_controller.py
+++ b/backend/controller/timesheet_controller.py
@@ -70,15 +70,19 @@ class TimesheetController(MethodView):
         """
         #TODO: Get Methode falls Felder fehlen / Wiederholte Codezeilen -> Prüfung auslagern
         if not request.is_json:
-            return jsonify({'error': 'Request must be in JSON format'}), 400
+            return jsonify('Request must be in JSON format'), 400
         request_data = request.get_json()
         if request_data is None:
-            return jsonify({'error': 'Request data is missing'}), 400
-        username = request_data['username']
+            return jsonify('Request data is missing'), 400
+        username = request_data.get('username')
         month = request_data['month']
-        year = request_data['year']
-        if not username or not month or not year:
-            return jsonify({'error': 'Missing required fields'}), 400
+        year = request_data.get('year')
+        if not username:
+            return jsonify('No username provided'), 400
+        if not month:
+            return jsonify('No month provided'), 400
+        if not year:
+            return jsonify('No year provided'), 400
         result = self.timesheet_service.ensure_timesheet_exists(username, month, year)
         return jsonify(result.message), result.status_code
 
@@ -91,13 +95,13 @@ class TimesheetController(MethodView):
         :return: JSON response containing the status message and status code.
         """
         if not request.is_json:
-            return jsonify({'error': 'Request data must be in JSON format'}), 400
+            return jsonify('Request data must be in JSON format'), 400
         request_data = request.get_json()
         timesheet_id = request_data['_id']
         if timesheet_id is None:
-            return jsonify({'error': 'No timesheet ID provided'}), 400
+            return jsonify( 'No timesheet ID provided'), 400
         if not self.file_service.does_file_exist(get_jwt_identity(), FileType.SIGNATURE):
-            return jsonify({'error': 'No signature has been uploaded.'}), 400
+            return jsonify('No signature has been uploaded.'), 400
         result = self.timesheet_service.sign_timesheet(timesheet_id)
         return jsonify(result.message), result.status_code
 
@@ -110,13 +114,13 @@ class TimesheetController(MethodView):
         :return: JSON response containing the status message and status code.
         """
         if not request.is_json:
-            return jsonify({'error': 'Request data must be in JSON format'}), 400
+            return jsonify( 'Request data must be in JSON format'), 400
         request_data = request.get_json()
         timesheet_id = request_data['_id']
         if timesheet_id is None:
-            return jsonify({'error': 'No timesheet ID provided'}), 400
+            return jsonify('No timesheet ID provided'), 400
         if not self.file_service.does_file_exist(get_jwt_identity(), FileType.SIGNATURE):
-            return jsonify({'error': 'No signature has been uploaded.'}), 400
+            return jsonify('No signature has been uploaded.'), 400
         result = self.timesheet_service.approve_timesheet(timesheet_id)
         return jsonify(result.message), result.status_code
 
@@ -129,13 +133,13 @@ class TimesheetController(MethodView):
         :return: JSON response containing the status message and status code.
         """
         if not request.is_json:
-            return jsonify({'error': 'Request data must be in JSON format'}), 400
+            return jsonify('Request data must be in JSON format'), 400
         request_data = request.get_json()
         timesheet_id = request_data['_id']
         if timesheet_id is None:
-            return jsonify({'error': 'No timesheet ID provided'}), 400
+            return jsonify('No timesheet ID provided'), 400
         if not self.file_service.does_file_exist(get_jwt_identity(), FileType.SIGNATURE):
-            return jsonify({'error': 'No signature has been uploaded.'}), 400
+            return jsonify('No signature has been uploaded.'), 400
         result = self.timesheet_service.request_change(timesheet_id)
         return jsonify(result.message), result.status_code
 
@@ -150,7 +154,7 @@ class TimesheetController(MethodView):
         request_data = request.args
         username = request_data.get('username')
         if username is None:
-            return jsonify({'error': 'No username provided'}), 400
+            return jsonify('No username provided'), 400
         result = self.timesheet_service.get_timesheets_by_username(username)
         if result.status_code != 200:
             return jsonify(result.message), result.status_code
@@ -169,8 +173,12 @@ class TimesheetController(MethodView):
         month = int(request_data.get('month'))
         year = int(request_data.get('year'))
         print(username, month, year)
-        if username is None or month is None or year is None:
-            return jsonify({'error': 'Missing required fields'}), 400
+        if username is None:
+            return jsonify('No username provided'), 400
+        if month is None:
+            return jsonify('No month provided'), 400
+        if year is None:
+            return jsonify('No year provided'), 400
         result = self.timesheet_service.get_timesheet(username, month, year)
         if result.status_code != 200:
             return jsonify(result.message), result.status_code
@@ -185,7 +193,7 @@ class TimesheetController(MethodView):
         """
         username = request.args.get('username')
         if username is None:
-            return jsonify({'error': 'No username provided'}), 400
+            return jsonify('No username provided'), 400
         result = self.timesheet_service.get_current_timesheet(username)
         if result.status_code != 200:
             return jsonify(result.message), result.status_code
@@ -200,7 +208,7 @@ class TimesheetController(MethodView):
         """
         username = request.args.get('username')
         if username is None:
-            return jsonify({'error': 'No username provided'}), 400
+            return jsonify('No username provided'), 400
         result = self.timesheet_service.get_highest_priority_timesheet(username)
         if result.status_code != 200:
             return jsonify(result.message), result.status_code
@@ -218,12 +226,14 @@ class TimesheetController(MethodView):
         request_data = request.args
         username = request_data.get('username')
         status = request_data.get('status')
-        if username is None or status is None:
-            return jsonify({'error': 'Missing required fields'}), 400
+        if username is None:
+            return jsonify('No username provided'), 400
+        if status is None:
+            return jsonify('No status provided'), 400
         #TODO: changes status in timesheet service to string and convert there
         timesheets = self.timesheet_service.get_timesheets_by_username_status(username, status).data
         if timesheets is None or len(timesheets) == 0:
-            return jsonify({'error': 'No timesheets found'}), 404
+            return jsonify('No timesheets found'), 404
         return jsonify([timesheet.to_str_dict() for timesheet in timesheets]), 200
 
     def _dispatch_request(self, endpoint_mapping):
@@ -237,4 +247,4 @@ class TimesheetController(MethodView):
         for path, func in endpoint_mapping.items():
             if request_path.endswith(path):
                 return func()
-        return jsonify({'error': 'Endpoint not found'}), 404
+        return jsonify('Endpoint not found'), 404

--- a/backend/controller/user_controller.py
+++ b/backend/controller/user_controller.py
@@ -82,7 +82,7 @@ class UserController(MethodView):
         for path, func in endpoint_mapping.items():
             if request_path.endswith(path):
                 return func()
-        return jsonify({'error': 'Endpoint not found'}), 404
+        return jsonify('Endpoint not found'), 404
 
     @jwt_required()
     @check_access(roles=[UserRole.ADMIN])
@@ -93,7 +93,7 @@ class UserController(MethodView):
         :return: JSON response containing the status message and status code.
         """
         if not request.is_json:
-            return jsonify({'error': 'Request data must be in JSON format'}), 400
+            return jsonify('Request data must be in JSON format'), 400
         user_data = request.get_json()
         result = self.user_service.create_user(user_data)
         return jsonify(result.message), result.status_code
@@ -107,7 +107,7 @@ class UserController(MethodView):
         :return: JSON response containing the status message and status code.
         """
         if not request.is_json:
-            return jsonify({'error': 'Request data must be in JSON format'}), 400
+            return jsonify('Request data must be in JSON format'), 400
         user_data = request.get_json()
         result = self.user_service.update_user(user_data)
         return jsonify(result.message), result.status_code
@@ -122,7 +122,7 @@ class UserController(MethodView):
         :return: JSON response containing the status message and status code.
         """
         if not request.is_json:
-            return jsonify({'error': 'Request data must be in JSON format'}), 400
+            return jsonify('Request data must be in JSON format'), 400
         username_data = request.get_json()
         result = self.user_service.delete_user(username_data['username'])
         return jsonify(result.message), result.status_code
@@ -134,7 +134,7 @@ class UserController(MethodView):
         :return: JSON response containing the status message and status code.
         """
         if not request.is_json:
-            return jsonify({'error': 'Request data must be in JSON format'}), 400
+            return jsonify('Request data must be in JSON format'), 400
         credentials = request.get_json()
         result = self.auth_service.login(credentials['username'], credentials['password'])
         if not result.is_successful:
@@ -159,7 +159,7 @@ class UserController(MethodView):
         :return: JSON response with the result of the password reset attempt.
         """
         if not request.is_json:
-            return jsonify({'error': 'Request data must be in JSON format'}), 400
+            return jsonify('Request data must be in JSON format'), 400
         credentials = request.get_json()
         username = credentials.get('username', get_jwt_identity())
         result = self.auth_service.reset_password(get_jwt_identity(), username, credentials['password'])
@@ -197,7 +197,7 @@ class UserController(MethodView):
         """
         args = request.args
         if 'role' not in args:
-            return jsonify({'error': 'Role parameter is required'}), 400
+            return jsonify('Role parameter is required'), 400
         role = args['role']
         result = self.user_service.get_users_by_role(role)
         users_data = [user.to_dict() for user in result.data]
@@ -240,17 +240,17 @@ class UserController(MethodView):
         file_type = FileType.get_type_by_value(request.args.get('fileType'))
 
         if file_type == FileType.SIGNATURE and username != get_jwt_identity():
-            return jsonify({'error': 'You are not authorized to access this file'}), 403
+            return jsonify('You are not authorized to access this file'), 403
 
         if not username:
-            return jsonify({'error': 'Username is required'}), 400
+            return jsonify('Username is required'), 400
 
         if not file_type:
-            return jsonify({'error': 'Valid File type is required'}), 400
+            return jsonify('Valid File type is required'), 400
 
         file_stream = self.file_service.get_image(username, file_type)
         if not file_stream:
-            return jsonify({'error': 'File not found'}), 404
+            return jsonify('File not found'), 404
 
         return send_file(
             file_stream,
@@ -285,7 +285,7 @@ class UserController(MethodView):
         request_args = request.args
 
         if len(request_args) > 0 and user.role == UserRole.HIWI:
-            return jsonify({'error': 'Invalid Arguments.'}), 400
+            return jsonify('Invalid Arguments.'), 400
         if user.role == UserRole.SECRETARY and 'username' in request_args:
             username = request_args['username']
             result = self.user_service.get_supervisor(username, True)
@@ -323,10 +323,10 @@ class UserController(MethodView):
         username = request.args.get('username')
         file_type = FileType.get_type_by_value(request.args.get('fileType'))
         if not username:
-            return jsonify({'error': 'Username is required'}), 400
+            return jsonify('Username is required'), 400
 
         if not file_type:
-            return jsonify({'error': 'Valid File type is required'}), 400
+            return jsonify('Valid File type is required'), 400
 
         result = self.file_service.delete_image(username, file_type)
         return jsonify(result.message), result.status_code


### PR DESCRIPTION
This Pull Request standardizes all error messages returned by the backend. To facilitate easier error parsing in the frontend, the "error:" prefix has been removed, leaving only the error message string.

Additionally, some error messages have been improved for better clarity. Now, you will know exactly which field is missing when using an endpoint, or why certain document data could not be gathered (e.g., due to a missing signature).

This Pull Request solves Issue #134 