### PR TITLE
Return most recent timesheet if all timesheets are complete.

### DIFF
--- a/backend/controller/timesheet_controller.py
+++ b/backend/controller/timesheet_controller.py
@@ -211,6 +211,8 @@ class TimesheetController(MethodView):
         username = request.args.get('username')
         if username is None:
             return jsonify('No username provided'), 400
+        if check_access(roles=[UserRole.HIWI]) and username != get_jwt_identity():
+            return jsonify('Hiwis can only access their own timesheets'), 403
         result = self.timesheet_service.get_highest_priority_timesheet(username)
         if result.status_code != 200:
             return jsonify(result.message), result.status_code

--- a/backend/service/timesheet_service.py
+++ b/backend/service/timesheet_service.py
@@ -315,6 +315,8 @@ class TimesheetService:
             self._get_status_priority(timesheet.status), timesheet.year, timesheet.month))
         if sorted_timesheets is None or len(sorted_timesheets) == 0:
             return RequestResult(False, "No timesheets found", 404)
+        if sorted_timesheets[0].status == TimesheetStatus.COMPLETE:
+            return RequestResult(True, "", 200, sorted_timesheets[-1])
         return RequestResult(True, "", 200, sorted_timesheets[0])
 
     def _get_status_priority(self, status: TimesheetStatus): #pragma: no cover


### PR DESCRIPTION
Changed the get_highest_priority_timesheet to return the most recent one if all timesheets are completed.
Also restricted the endpoint access, so hiwis can't access other hiwis' timesheets.