### PR TITLE
Added vacationMinutes field to timesheet

### DIFF
--- a/backend/model/timesheet.py
+++ b/backend/model/timesheet.py
@@ -18,12 +18,11 @@ class Timesheet:
         total_time (float): Total hours recorded in the timesheet.
         overtime (float): Total overtime hours recorded in the timesheet.
         last_signature_change (datetime): Timestamp of the last signature or approval change.
-        time_entry_ids (list[ObjectId]): List of ObjectIds corresponding to the time entries included in the timesheet.
     """
 
     def __init__(self, username: str, month: int, year: int,
                  timesheet_id=None, status=TimesheetStatus.NOT_SUBMITTED, total_time=0.0,
-                 overtime=0.0, last_signature_change=datetime.utcnow()):
+                 overtime=0.0, last_signature_change=datetime.utcnow(), vacation_minutes=0.0):
         """
         Initializes a new Timesheet object with the given parameters.
 
@@ -43,6 +42,8 @@ class Timesheet:
         :type overtime: float
         :param last_signature_change: The datetime of the last signature update, defaults to current time.
         :type last_signature_change: datetime
+        :param vacation_minutes: The total vacation minutes in this timesheet, defaults to 0.0.
+        :type vacation_minutes: float
         """
         self.timesheet_id = timesheet_id
         self.username = username
@@ -52,6 +53,7 @@ class Timesheet:
         self.total_time = total_time
         self.overtime = overtime
         self.last_signature_change = last_signature_change
+        self.vacation_minutes = vacation_minutes
 
     @staticmethod
     def from_dict(timesheet_dict: dict):
@@ -72,7 +74,8 @@ class Timesheet:
             status=TimesheetStatus(timesheet_dict.get("status", TimesheetStatus.NOT_SUBMITTED)),
             total_time=timesheet_dict.get("totalTime", 0.0),
             overtime=timesheet_dict.get("overtime", 0.0),
-            last_signature_change=timesheet_dict.get("lastSignatureChange", datetime.utcnow())
+            last_signature_change=timesheet_dict.get("lastSignatureChange", datetime.utcnow()),
+            vacation_minutes=timesheet_dict.get("vacationMinutes", 0.0)
         )
         return timesheet
 
@@ -100,7 +103,8 @@ class Timesheet:
                 "status": str(self.status),
                 "totalTime": self.total_time,
                 "overtime": self.overtime,
-                "lastSignatureChange": self.last_signature_change
+                "lastSignatureChange": self.last_signature_change,
+                "vacationMinutes": self.vacation_minutes
             }
         return {
             "_id": self.timesheet_id,
@@ -110,7 +114,8 @@ class Timesheet:
             "status": str(self.status),
             "totalTime": self.total_time,
             "overtime": self.overtime,
-            "lastSignatureChange": self.last_signature_change
+            "lastSignatureChange": self.last_signature_change,
+            "vacationMinutes": self.vacation_minutes
         }
 
     def to_str_dict(self):
@@ -128,5 +133,6 @@ class Timesheet:
             "status": str(self.status),
             "totalTime": self.total_time,
             "overtime": self.overtime,
-            "lastSignatureChange": self.last_signature_change
+            "lastSignatureChange": self.last_signature_change,
+            "vacationMinutes": self.vacation_minutes
         }

--- a/backend/service/time_entry_service.py
+++ b/backend/service/time_entry_service.py
@@ -95,7 +95,7 @@ class TimeEntryService:
             self.user_service.remove_vacation_minutes(username, time_entry.get_duration())
         self.user_service.add_overtime_minutes(username, time_entry.get_duration())
 
-        result = self.timesheet_service.set_total_time(time_entry.timesheet_id)
+        result = self.timesheet_service.set_total_and_vacation_time(time_entry.timesheet_id)
         if not result.is_successful:
             return result
 
@@ -197,7 +197,7 @@ class TimeEntryService:
             elif update_entry.get_duration() > existing_entry.get_duration():
                 self.user_service.remove_overtime_minutes(get_jwt_identity(), update_entry.get_duration() - existing_entry.get_duration())
             return repo_result
-        result = self.timesheet_service.set_total_time(updated_time_entry.timesheet_id)
+        result = self.timesheet_service.set_total_and_vacation_time(updated_time_entry.timesheet_id)
         if not result.is_successful:
             return result
         if validation_result.status == ValidationStatus.WARNING:
@@ -233,7 +233,7 @@ class TimeEntryService:
         self.user_service.remove_overtime_minutes(get_jwt_identity(), time_entry.get_duration())
         self.timesheet_service.calculate_overtime(time_entry_data['timesheetId'])
 
-        result = self.timesheet_service.set_total_time(time_entry.timesheet_id)
+        result = self.timesheet_service.set_total_and_vacation_time(time_entry.timesheet_id)
         if not result.is_successful and delete_result.is_successful:
             result.message = "Time entry deleted, but total hours could not be updated."
             return result

--- a/backend/tests/service/test_timesheet_service.py
+++ b/backend/tests/service/test_timesheet_service.py
@@ -44,12 +44,12 @@ class TestTimesheetService(unittest.TestCase):
 
     def test_set_total_time(self):
         # Test invalid timesheet id
-        result_invalid_timesheet_id = self.timesheet_service.set_total_time("666666666666666666666666")
+        result_invalid_timesheet_id = self.timesheet_service.set_total_and_vacation_time("666666666666666666666666")
         self.assertEqual("Timesheet not found", result_invalid_timesheet_id.message)
         self.assertFalse(result_invalid_timesheet_id.is_successful)
         self.assertEqual(404, result_invalid_timesheet_id.status_code)
 
-        result = self.timesheet_service.set_total_time(ObjectId('6679ca2935df0d8f7202c5fa'))
+        result = self.timesheet_service.set_total_and_vacation_time(ObjectId('6679ca2935df0d8f7202c5fa'))
         self.assertEqual("Total time updated", result.message)
         self.assertTrue(result.is_successful)
         self.assertEqual(200, result.status_code)


### PR DESCRIPTION
This PR addresses Issue #131 by adding a new vacationMinutes field to the timesheet object. To ensure that the total_time value is calculated consistently with the vacationMinutes, I renamed the set_total_time method to set_total_and_vacation_time. 
This update allows both total time and vacation minutes to be calculated simultaneously, reducing complexity and eliminating redundant code.