### PR TITLE
Issue #232 - lack of validation for timesheet creation order

### DIFF
--- a/backend/service/timesheet_service.py
+++ b/backend/service/timesheet_service.py
@@ -56,7 +56,9 @@ class TimesheetService:
         user = self.user_service.get_profile(username)
         if user is None:
             return RequestResult(False, "User not found", 404)
-        if user.account_creation > datetime(year, month, 1):
+
+        account_creation_month_year = datetime(year=user.account_creation.year, month=user.account_creation.month, day=1)
+        if account_creation_month_year > datetime(year, month, 1):
             return RequestResult(False, "User account was created after the timesheet month", 400)
         creation_result = self._create_timesheet(username, month, year)
         if creation_result.status_code == 201:


### PR DESCRIPTION
To prevent Hiwis from generating unlimited vacation hours, this PR prohibits the creation of a timesheet for any period before the Hiwi's account was created.