### PR TITLE
Fix Account Creation Timestamp

### DIFF
--- a/backend/model/user/user.py
+++ b/backend/model/user/user.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 
 from db import initialize_db
 from model.user.personal_information import PersonalInfo
@@ -23,7 +23,7 @@ class User:
         self.password_hash = password_hash
         self.personal_info = personal_info
         self.role = role
-        self.account_creation = account_creation or datetime.datetime.utcnow()
+        self.account_creation = account_creation or datetime.now(timezone.utc)
         self.last_login = None
         self.slack_id = slack_id
 


### PR DESCRIPTION
- Fix account creation timestamp to load current timestamp #249 

- Identified that the problem originated from using a default argument value for the account creation time in Python functions. **Note and Good to know:** **Default argument values are evaluated only once when the function is defined, not each time the function is called.**
- This caused all users to share the same timestamp from the initial function load.